### PR TITLE
Convert joint genotype workflow outputs to use the non-deprecated syntax

### DIFF
--- a/joint-discovery-gatk4.wdl
+++ b/joint-discovery-gatk4.wdl
@@ -337,18 +337,15 @@ workflow JointGenotyping {
 
   output {
     # outputs from the small callset path through the wdl
-    FinalGatherVcf.output_vcf
-    FinalGatherVcf.output_vcf_index
-    CollectMetricsOnFullVcf.detail_metrics_file
-    CollectMetricsOnFullVcf.summary_metrics_file
+    File? output_vcf = FinalGatherVcf.output_vcf
+    File? output_vcf_index = FinalGatherVcf.output_vcf_index
 
-    # outputs from the large callset path through the wdl
-    # (note that we do not list ApplyRecalibration here because it is run in both paths)
-    GatherMetrics.detail_metrics_file
-    GatherMetrics.summary_metrics_file
+    # select metrics from the small callset path and the large callset path
+    File detail_metrics_file = select_first([CollectMetricsOnFullVcf.detail_metrics_file, GatherMetrics.detail_metrics_file])
+    File summary_metrics_file = select_first([CollectMetricsOnFullVcf.summary_metrics_file, GatherMetrics.summary_metrics_file])
 
     # output the interval list generated/used by this run workflow
-    DynamicallyCombineIntervals.output_intervals
+    File output_intervals = DynamicallyCombineIntervals.output_intervals
   }
 }
 


### PR DESCRIPTION
This allows the joint genotype workflow to be used as a subworkflow. Without this fix, attempting to use it as such results in an error