### PR TITLE
HC annot fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ it easier to configure the workflow.*
 #### Requirements/expectations
 - One or more GVCFs produced by HaplotypeCaller in GVCF mode
 - Bare minimum 50 samples. Gene panels are not supported.
-- When determining disk size in the JSON, use the guideline below
-  - small_disk = (num_gvcfs / 10) + 10
-  - medium_disk = (num_gvcfs * 15) + 10
-  - huge_disk = num_gvcfs + 10
 
 ### Outputs 
 - A VCF file and its index, filtered using variant quality score recalibration  

--- a/haplotypecaller-gvcf-gatk4.wdl
+++ b/haplotypecaller-gvcf-gatk4.wdl
@@ -39,7 +39,8 @@ workflow HaplotypeCallerGvcf_GATK4 {
     File scattered_calling_intervals_list
   
     Boolean make_gvcf = true
-    String gatk_docker = "broadinstitute/gatk:4.1.4.0"
+    Boolean make_bamout = false
+    String gatk_docker = "broadinstitute/gatk:4.1.7.0"
     String gatk_path = "/gatk/gatk"
     String gitc_docker = "broadinstitute/genomes-in-the-cloud:2.3.1-1500064817"
     String samtools_path = "samtools"
@@ -84,11 +85,13 @@ workflow HaplotypeCallerGvcf_GATK4 {
         input_bam_index = select_first([CramToBamTask.output_bai, input_bam_index]),
         interval_list = interval_file,
         output_filename = output_filename,
+        vcf_basename = vcf_basename,
         ref_dict = ref_dict,
         ref_fasta = ref_fasta,
         ref_fasta_index = ref_fasta_index,
         hc_scatter = hc_divisor,
         make_gvcf = make_gvcf,
+        make_bamout = make_bamout,
         docker = gatk_docker,
         gatk_path = gatk_path
     }
@@ -163,11 +166,13 @@ task HaplotypeCaller {
     File input_bam_index
     File interval_list
     String output_filename
+    String vcf_basename
     File ref_dict
     File ref_fasta
     File ref_fasta_index
     Float? contamination
     Boolean make_gvcf
+    Boolean make_bamout
     Int hc_scatter
 
     String gatk_path
@@ -189,6 +194,8 @@ task HaplotypeCaller {
   Float ref_size = size(ref_fasta, "GB") + size(ref_fasta_index, "GB") + size(ref_dict, "GB")
   Int disk_size = ceil(((size(input_bam, "GB") + 30) / hc_scatter) + ref_size) + 20
   
+  String bamout_arg = if make_bamout then "-bamout ~{vcf_basename}.bamout.bam" else ""
+
   parameter_meta {
     input_bam: {
       description: "a bam file",
@@ -208,8 +215,14 @@ task HaplotypeCaller {
       -I ~{input_bam} \
       -L ~{interval_list} \
       -O ~{output_filename} \
-      -contamination ~{default=0 contamination} ~{true="-ERC GVCF" false="" make_gvcf} \
-      -G StandardAnnotation -G AS_StandardAnnotation -G StandardHCAnnotation
+      -contamination ~{default=0 contamination} \
+      -G StandardAnnotation -G StandardHCAnnotation ~{true="-G AS_StandardAnnotation" false="" make_gvcf} \
+      -GQB 10 -GQB 20 -GQB 30 -GQB 40 -GQB 50 -GQB 60 -GQB 70 -GQB 80 -GQB 90 \
+      ~{true="-ERC GVCF" false="" make_gvcf} \
+      ~{bamout_arg}
+
+    # Cromwell doesn't like optional task outputs, so we have to touch this file.
+    touch ~{vcf_basename}.bamout.bam 
   }
   runtime {
     docker: docker
@@ -220,6 +233,7 @@ task HaplotypeCaller {
   output {
     File output_vcf = "~{output_filename}"
     File output_vcf_index = "~{output_filename}.tbi"
+    File bamout = "~{vcf_basename}.bamout.bam"
   }
 }
 # Merge GVCFs generated per-interval for the same sample

--- a/haplotypecaller-gvcf-gatk4.wdl
+++ b/haplotypecaller-gvcf-gatk4.wdl
@@ -216,7 +216,6 @@ task HaplotypeCaller {
       -O ~{output_filename} \
       -contamination ~{default=0 contamination} \
       -G StandardAnnotation -G StandardHCAnnotation ~{true="-G AS_StandardAnnotation" false="" make_gvcf} \
-      -new-qual \
       -GQB 10 -GQB 20 -GQB 30 -GQB 40 -GQB 50 -GQB 60 -GQB 70 -GQB 80 -GQB 90 \
       ~{true="-ERC GVCF" false="" make_gvcf} \
       ~{bamout_arg}

--- a/haplotypecaller-gvcf-gatk4.wdl
+++ b/haplotypecaller-gvcf-gatk4.wdl
@@ -217,6 +217,7 @@ task HaplotypeCaller {
       -O ~{output_filename} \
       -contamination ~{default=0 contamination} \
       -G StandardAnnotation -G StandardHCAnnotation ~{true="-G AS_StandardAnnotation" false="" make_gvcf} \
+      -new-qual \
       -GQB 10 -GQB 20 -GQB 30 -GQB 40 -GQB 50 -GQB 60 -GQB 70 -GQB 80 -GQB 90 \
       ~{true="-ERC GVCF" false="" make_gvcf} \
       ~{bamout_arg}

--- a/haplotypecaller-gvcf-gatk4.wdl
+++ b/haplotypecaller-gvcf-gatk4.wdl
@@ -85,7 +85,6 @@ workflow HaplotypeCallerGvcf_GATK4 {
         input_bam_index = select_first([CramToBamTask.output_bai, input_bam_index]),
         interval_list = interval_file,
         output_filename = output_filename,
-        vcf_basename = vcf_basename,
         ref_dict = ref_dict,
         ref_fasta = ref_fasta,
         ref_fasta_index = ref_fasta_index,
@@ -166,7 +165,6 @@ task HaplotypeCaller {
     File input_bam_index
     File interval_list
     String output_filename
-    String vcf_basename
     File ref_dict
     File ref_fasta
     File ref_fasta_index
@@ -193,7 +191,8 @@ task HaplotypeCaller {
 
   Float ref_size = size(ref_fasta, "GB") + size(ref_fasta_index, "GB") + size(ref_dict, "GB")
   Int disk_size = ceil(((size(input_bam, "GB") + 30) / hc_scatter) + ref_size) + 20
-  
+
+  String vcf_basename = if make_gvcf then  basename(output_filename, ".gvcf") else basename(output_filename, ".vcf")
   String bamout_arg = if make_bamout then "-bamout ~{vcf_basename}.bamout.bam" else ""
 
   parameter_meta {


### PR DESCRIPTION
- Proposed fix for user error message when using VCF mode for HC: [gatk forum ticket](https://gatk.broadinstitute.org/hc/en-us/community/posts/360062926072-Error-on-Google-Cloud-Platform-haplotypecaller-gvcf-gatk-wdl-with-make-gvcf-false?page=1#community_comment_360010525811)
  - HC command was updated to replicate dsde-piplines command [here](https://github.com/broadinstitute/dsde-pipelines/blob/5cbe5dd327de0b4a29f39d704df4ee02d687e6b7/tasks/GermlineVariantDiscovery.wdl#L110). A conditional was added to use "AS_StandardAnnotation" only if make_gvcf is set to true
- HC workflow updated to use gatk4.1.7.0
- Removed suggested disksize in ReadMe, there is no reference for the suggestion and the wdl was been updated since the time suggestion was made. 