### PR TITLE
Updated JointGenotyping wdl to version 1.3.0

### DIFF
--- a/JointGenotyping.wdl
+++ b/JointGenotyping.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-## Copyright Broad Institute, 2019
+## Copyright Broad Institute, 2020
 ## 
 ## This WDL implements the joint discovery and VQSR filtering portion of the GATK 
 ## Best Practices (June 2016) for germline SNP and Indel discovery in human 
@@ -51,7 +51,7 @@ import "./tasks/JointGenotypingTasks.wdl" as Tasks
 # Joint Genotyping for hg38 Whole Genomes and Exomes (has not been tested on hg19)
 workflow JointGenotyping {
 
-  String pipeline_version = "1.2"
+  String pipeline_version = "1.3.0"
 
   input {
     File unpadded_intervals_file
@@ -497,5 +497,8 @@ workflow JointGenotyping {
 
     # Output the metrics from crosschecking fingerprints.
     File crosscheck_fingerprint_check = select_first([CrossCheckFingerprintSolo.crosscheck_metrics, GatherFingerprintingMetrics.gathered_metrics])
+  }
+  meta {
+    allowNestedInputs: true
   }
 }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ file with 50 or more GVCFs and produces a multisample VCF.
 
 *NOTE:*  
 *- To create a sample map use the [generate-sample-map](https://portal.firecloud.org/?return=terra#methods/gatk/generate-sample-map/1) workflow.*
-
+*- This workflow will soon be removed from this repo. Its new repository location will be [broadinstitute/warp](https://github.com/broadinstitute/warp) *
 
 #### Requirements/expectations
 - A sample map listing 50 or more GVCFs produced by HaplotypeCaller in GVCF mode.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ in human whole-genome sequencing (WGS). The workflow requires a sample map
 file with 50 or more GVCFs and produces a multisample VCF.
 
 *NOTE:*  
-*- To create a sample map use the [generate-sample-map](https://portal.firecloud.org/?return=terra#methods/gatk/generate-sample-map/1) workflow.*
-*- This workflow will soon be removed from this repo. Its new repository location will be [broadinstitute/warp](https://github.com/broadinstitute/warp) *
+*- To create a sample map use the [generate-sample-map](https://portal.firecloud.org/?return=terra#methods/gatk/generate-sample-map/1) workflow.*  
+*- This workflow will soon be removed from this repo. Its new repository location will be [broadinstitute/warp](https://github.com/broadinstitute/warp)*
 
 #### Requirements/expectations
 - A sample map listing 50 or more GVCFs produced by HaplotypeCaller in GVCF mode.

--- a/tasks/JointGenotypingTasks.wdl
+++ b/tasks/JointGenotypingTasks.wdl
@@ -58,7 +58,7 @@ task SplitIntervalList {
   command <<<
     gatk --java-options -Xms3g SplitIntervals \
       -L ~{interval_list} -O  scatterDir -scatter ~{scatter_count} -R ~{ref_fasta} \
-      -mode ~{scatter_mode}
+      -mode ~{scatter_mode} --interval-merging-rule OVERLAPPING_ONLY
    >>>
 
   runtime {


### PR DESCRIPTION
Updated JointGenotyping to 1.3.0:

- Fix SplitIntervals task so that it works for abutting WGS intervals. Increase by chromosome scatter count appropriately for WGS as fallback.